### PR TITLE
Add debounce to search and guarantee that results are new

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5504,6 +5504,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-debounce": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-5.2.0.tgz",
+      "integrity": "sha512-lW4tbPsTnvPKYqOYXp5xZ7SP7No/ARLqqQqoyRKuSzP0HxR9arhSAhznXUZFoNPWDRij8fog+N6sYbjb8c3kzw=="
+    },
     "use-subscription": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sass": "^1.29.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.1",
+    "use-debounce": "^5.2.0",
     "vis": "^4.21.0-EOL",
     "vis-timeline": "^7.4.2"
   },

--- a/src/Components/Nav/TopBar/SearchBar.tsx
+++ b/src/Components/Nav/TopBar/SearchBar.tsx
@@ -1,11 +1,14 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Search, SearchResultData, SearchResultProps } from 'semantic-ui-react'
 import { useRouter } from 'next/router'
 import { splitName } from '../../../util/playerNames'
 import { getMapImageByName } from '../../Sections/Maps/mapsImages'
+import { useDebounce } from 'use-debounce'
 
 export const SearchBar = (props) => {
   const [search, setSearch] = useState('')
+  const timestampOfSearchRequest = useRef<number>(Date.now ())
+  const [debouncedSearch] = useDebounce(search, 400)
   const [loading, setLoading] = useState(false)
   const [results, setResults] = useState([])
   const router = useRouter()
@@ -13,17 +16,30 @@ export const SearchBar = (props) => {
   const handleSearchChange = async (event: React.MouseEvent, data: SearchResultData) => {
     let newValue = data.value
     setSearch(newValue)
-    if (newValue === '') {
+  }
+
+  const startSearch = async (searchString) => {
+    if (searchString === '') {
       setResults([])
       return
     }
+
+    const timestampBeforeRequest = Date.now()
     setLoading(true)
-    const response = await fetch(`/api/search?q=${newValue}`)
+    const response = await fetch(`/api/search?q=${searchString}`)
     const json = await response.json()
     const results = json.results
-    setResults(results)
-    setLoading(false)
+
+    if (timestampBeforeRequest > timestampOfSearchRequest.current) {
+      timestampOfSearchRequest.current = timestampBeforeRequest
+      setResults(results)
+      setLoading(false)
+    }
   }
+
+  useEffect(() => {
+    startSearch(debouncedSearch)
+  }, [debouncedSearch])
 
   const onResultSelect = (e: React.MouseEvent<HTMLDivElement>, data: SearchResultData) => {
     const item = data.result.item


### PR DESCRIPTION
Closes #25 
Uses the use-debounce package to debounce searchbar input. Use timestamp to guarantee that now old responses are used as results. 