### PR TITLE
Add buttons to navigate trough games of a tournament

### DIFF
--- a/pages/api/tournament/[tid]/matches/[mid].js
+++ b/pages/api/tournament/[tid]/matches/[mid].js
@@ -1,5 +1,6 @@
 import tournaments from '../../../../../data/tournaments/tournaments.json'
 import fs from 'fs'
+import { flattenTournamentTree } from '../../../../../src/util/flattenTournamentTree'
 
 const tournamentsPath = 'data/tournaments'
 
@@ -28,12 +29,26 @@ export default async (req, res) => {
     const heatmapFile = await fs.promises.readFile(`${tournamentsPath}/${tid}/matches/heatmaps/${mid}.json`)
     const unitsBuiltFile = await fs.promises.readFile(`${tournamentsPath}/${tid}/matches/unitsBuilt/${mid}.json`)
     const upgradesFile = await fs.promises.readFile(`${tournamentsPath}/${tid}/matches/upgrades/${mid}.json`)
+    const treeFile = await fs.promises.readFile(`${tournamentsPath}/${tid}/tree.json`)
 
     const tournamentMeta = JSON.parse(tournamentMetaFile)
     const matchMeta = JSON.parse(matchMetaFile)
     const heatmap = JSON.parse(heatmapFile)
     const unitsBuilt = JSON.parse(unitsBuiltFile)
     const upgrades = JSON.parse(upgradesFile)
+    const tree = JSON.parse(treeFile)
+
+    // get tournament tree, flatten it, find currente game, and extract previous/next games
+    const allGames = flattenTournamentTree(tree)
+    const gameIndex = allGames.findIndex(node => node.id === mid)
+    let previousGameId = null
+    let nextGameId = null
+    if (gameIndex > 0) {
+      previousGameId = allGames[gameIndex - 1].id
+    }
+    if (gameIndex < allGames.length - 1) {
+      nextGameId = allGames[gameIndex + 1].id
+    }
 
     res.statusCode = 200
     res.json({
@@ -42,6 +57,9 @@ export default async (req, res) => {
       heatmap,
       unitsBuilt,
       upgrades,
+      gameIndex,
+      previousGameId,
+      nextGameId,
       status: 200
     })
   } catch (e) {

--- a/pages/tournament/[id]/games/[mid]/index.tsx
+++ b/pages/tournament/[id]/games/[mid]/index.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import Error from 'next/error'
 import { SegmentCustom } from '../../../../../src/Components/Segments/SegmentCustom'
+import { GameNavigation } from '../../../../../src/Components/Sections/SingleGame/GameNavigation'
 
 interface PageData {
   tournamentMeta: TournamentMeta
@@ -19,6 +20,8 @@ interface PageData {
   heatmap: Array<HeatmapDataPoint>
   unitsBuilt: { player1: UnitsBuilt, player2: UnitsBuilt }
   upgrades: { player1: {[upgradeId: string]: number}, player2: {[upgradeId: string]: number}}
+  previousGameId: null | string
+  nextGameId: null | string
 }
 
 const GameHome = () => {
@@ -106,9 +109,10 @@ const GameHome = () => {
         </Breadcrumb.Section>
         <Breadcrumb.Divider />
         <Breadcrumb.Section active>
-          {splitName(matchMeta.players[0]).name} vs {splitName(matchMeta.players[1]).name}
+          {splitName(matchMeta.players[0]).name} vs {splitName(matchMeta.players[1]).name} - {matchMeta.mapName}
         </Breadcrumb.Section>
       </Breadcrumb>
+      <GameNavigation tournamentId={id} previousGameId={data.previousGameId} nextGameId={data.nextGameId} />
       <SingleGameHeaderSection matchMeta={matchMeta} />
       <HeatmapSection dataPoints={data.heatmap} mapId={matchMeta.mapId} mapName={matchMeta.mapName} />
       <UnitsTwoPlayers units={[unitsBuilt.player1, unitsBuilt.player2]} names={matchMeta.players} />

--- a/src/Components/Sections/SingleGame/GameNavigation.tsx
+++ b/src/Components/Sections/SingleGame/GameNavigation.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import React from 'react'
+import { Button } from 'semantic-ui-react'
+
+interface Props {
+  tournamentId: string
+  previousGameId: null |string
+  nextGameId: null | string
+}
+
+export const GameNavigation = (props: Props) => {
+  const { tournamentId, nextGameId, previousGameId } = props
+  return (
+    <div className='d-flex justify-content-between my-4'>
+      {previousGameId !== null
+      ? (
+          <Link href={`/tournament/${tournamentId}/games/${previousGameId}`} passHref={true}>
+            <a>
+              <Button content='Previous' icon='left arrow' labelPosition='left' />
+            </a>
+          </Link>
+        )
+      : <div />}
+
+      {nextGameId !== null
+      ? (
+          <Link href={`/tournament/${tournamentId}/games/${nextGameId}`} passHref={true}>
+            <a>
+              <Button content='Next' icon='right arrow' labelPosition='right' />
+            </a>
+          </Link>
+        )
+      : <div />}
+
+    </div>
+  )
+}

--- a/src/util/flattenTournamentTree.ts
+++ b/src/util/flattenTournamentTree.ts
@@ -1,0 +1,10 @@
+import { TreeNode } from '../Components/Sections/Tournament/TournamentListItem'
+
+export const flattenTournamentTree = (tree: TreeNode): Array<TreeNode> => {
+  if (tree.type === 'file') {
+    return [tree]
+  }
+  if (tree.type === 'folder') {
+    return tree.children.flatMap(node => flattenTournamentTree(node))
+  }
+}


### PR DESCRIPTION
Add two buttons "Previous" and "Next" to the single game page. Those buttons allow to cycle through games in the order they appear in the tournament tree.

This implements the first half of #21 